### PR TITLE
Accept both number and string for the records field

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -38,7 +38,7 @@ type Domain struct {
 	GradeTitle       string      `json:"grade_title,omitempty"`
 	Status           string      `json:"status,omitempty"`
 	ExtStatus        string      `json:"ext_status,omitempty"`
-	Records          string      `json:"records,omitempty"`
+	Records          json.Number `json:"records,omitempty"`
 	GroupID          json.Number `json:"group_id,omitempty"`
 	IsMark           string      `json:"is_mark,omitempty"`
 	Remark           string      `json:"remark,omitempty"`

--- a/domains_test.go
+++ b/domains_test.go
@@ -40,13 +40,13 @@ func TestDomainsService_List(t *testing.T) {
 			"domains": [
 				{
 					"id": 2238269,
-					"status": "enable"
-
+					"status": "enable",
+					"records": "12"
 				},
 				{
 					"id": 10360095,
-					"status": "enable"
-
+					"status": "enable",
+					"records": 1
 				}
 			]}`)
 	})
@@ -57,7 +57,7 @@ func TestDomainsService_List(t *testing.T) {
 		t.Errorf("Domains.List returned error: %v", err)
 	}
 
-	want := []Domain{{ID: "2238269", Status: "enable"}, {ID: "10360095", Status: "enable"}}
+	want := []Domain{{ID: "2238269", Status: "enable", Records: "12"}, {ID: "10360095", Status: "enable", Records: "1"}}
 	if !reflect.DeepEqual(domains, want) {
 		t.Errorf("Domains.List returned %+v, want %+v", domains, want)
 	}


### PR DESCRIPTION
Domain.List API请求中新域名返回的records变成了整数和字符串的类型：
```
$ curl -X POST https://dnsapi.cn/Domain.List -d 'login_token=xxx&format=json'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2807    0  2744  100    63   9730    223 --:--:-- --:--:-- --:--:--  9953
{
    ...
    "domains": [
        {
            ...
            "records": 0,
            ...
        },
        {
            ...
            "records": "73",
            ...
        },
        {
            ...
            "records": "56",
            ...
        },
        {
            ...
            "records": "26",
            ...
        }
    ]
}
```
这个bug同时导致了cert-manager的dnspod hook报错：
```
Error presenting challenge: dnspod API call failed: json: cannot unmarshal number into Go struct field Domain.domains.records of type string
```

此commit把records的类型修改为json.Number以同时兼容整数和字符串，同时补上了相关的测试